### PR TITLE
Update Go to 1.16 ; Make docker-build work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
+	mkdir -p api controllers
 	docker build . -t ${IMG}
 
 # Push the docker image

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/giantswarm/capi-migration
 
-go 1.13
+go 1.16
 
 require (
 	k8s.io/apimachinery v0.17.2


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16104
Part of: https://github.com/giantswarm/capi-migration/pull/1

Commands that should work:

```
make
make test
make docker-build
```