### PR TITLE
Use unique SA

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,4 +36,5 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,4 +1,10 @@
 resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16104
Part of: https://github.com/giantswarm/capi-migration/pull/1

Diff for files generated with `kustomize build config/default`:

```diff
diff --git a/pawel.old.yaml b/pawel.new.yaml
index 2020fd2..69626b0 100644
--- a/pawel.old.yaml
+++ b/pawel.new.yaml
@@ -5,6 +5,12 @@ metadata:
     control-plane: controller-manager
   name: capi-migration-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capi-migration-controller-manager
+  namespace: capi-migration-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -104,7 +110,7 @@ roleRef:
   name: capi-migration-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: capi-migration-controller-manager
   namespace: capi-migration-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -117,7 +123,7 @@ roleRef:
   name: capi-migration-manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: capi-migration-controller-manager
   namespace: capi-migration-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -130,7 +136,7 @@ roleRef:
   name: capi-migration-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: capi-migration-controller-manager
   namespace: capi-migration-system
 ---
 apiVersion: v1
@@ -190,4 +196,5 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      serviceAccountName: capi-migration-controller-manager
       terminationGracePeriodSeconds: 10
```
