### PR TITLE
Add initial structure for migration implementation

### DIFF
--- a/pkg/migration/azure.go
+++ b/pkg/migration/azure.go
@@ -17,6 +17,10 @@ func NewAzureMigrator(cfg AzureMigrationConfig) (Migrator, error) {
 	return &azureMigrator{}, nil
 }
 
+func (m *azureMigrator) IsMigrated() (bool, error) {
+	return true, nil
+}
+
 func (m *azureMigrator) Prepare() error {
 	var err error
 

--- a/pkg/migration/azure.go
+++ b/pkg/migration/azure.go
@@ -42,7 +42,7 @@ func (m *azureMigrator) Prepare() error {
 	return nil
 }
 
-func (m *azureMigrator) Migrate() error {
+func (m *azureMigrator) TriggerMigration() error {
 	err := m.triggerMigration()
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/migration/azure.go
+++ b/pkg/migration/azure.go
@@ -1,6 +1,8 @@
 package migration
 
 import (
+	"fmt"
+
 	"github.com/giantswarm/microerror"
 )
 
@@ -36,6 +38,10 @@ func (m *azureMigrator) IsMigrated() (bool, error) {
 	return true, nil
 }
 
+func (m *azureMigrator) IsMigrating() (bool, error) {
+	return false, nil
+}
+
 func (m *azureMigrator) Prepare() error {
 	var err error
 
@@ -61,6 +67,14 @@ func (m *azureMigrator) TriggerMigration() error {
 	err := m.triggerMigration()
 	if err != nil {
 		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (m *azureMigrator) Cleanup() error {
+	if !m.IsMigrated() {
+		return fmt.Errorf("cluster has not migrated yet")
 	}
 
 	return nil

--- a/pkg/migration/azure.go
+++ b/pkg/migration/azure.go
@@ -1,0 +1,79 @@
+package migration
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+type AzureMigrationConfig struct {
+	// Migration configuration + dependencies such as k8s client.
+}
+
+type azureMigrator struct {
+	// Migration configuration, dependencies + intermediate cache for involved
+	// CRs.
+}
+
+func NewAzureMigrator(cfg AzureMigrationConfig) (Migrator, error) {
+	return &azureMigrator{}, nil
+}
+
+func (m *azureMigrator) Prepare() error {
+	var err error
+
+	err = m.readCRs()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = m.prepareMissingCRs()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = m.updateCRs()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (m *azureMigrator) Migrate() error {
+	err := m.triggerMigration()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// readCRs reads existing CRs involved in migration. For Azure this contains
+// roughly following CRs:
+// - AzureConfig
+// - Cluster
+// - AzureCluster
+// - MachinePools
+// - AzureMachinePools
+//
+func (m *azureMigrator) readCRs() error {
+	return nil
+}
+
+// prepareMissingCRs constructs missing CRs that are needed for CAPI+CAPZ
+// reconciliation to work. This include e.g. KubeAdmControlPlane and
+// AzureMachineTemplate for new master nodes.
+func (m *azureMigrator) prepareMissingCRs() error {
+	return nil
+}
+
+// updateCRs updates existing CRs such as Cluster and AzureCluster with
+// configuration that is compatible with upstream controllers.
+func (m *azureMigrator) updateCRs() error {
+	return nil
+}
+
+// triggerMigration executes the last missing updates on CRs so that
+// reconciliation transistions to upstream controllers.
+func (m *azureMigrator) triggerMigration() error {
+	return nil
+}

--- a/pkg/migration/azure.go
+++ b/pkg/migration/azure.go
@@ -8,13 +8,28 @@ type AzureMigrationConfig struct {
 	// Migration configuration + dependencies such as k8s client.
 }
 
+type azureMigratorFactory struct {
+	config AzureMigrationConfig
+}
+
 type azureMigrator struct {
+	clusterID string
+
 	// Migration configuration, dependencies + intermediate cache for involved
 	// CRs.
 }
 
-func NewAzureMigrator(cfg AzureMigrationConfig) (Migrator, error) {
-	return &azureMigrator{}, nil
+func NewAzureMigratorFactory(cfg AzureMigrationConfig) (MigratorFactory, error) {
+	return &azureMigratorFactory{
+		config: cfg,
+	}, nil
+}
+
+func (f *azureMigratorFactory) NewMigrator(clusterID string) (Migrator, error) {
+	return &azureMigrator{
+		clusterID: clusterID,
+		// rest of the config from f.config...
+	}, nil
 }
 
 func (m *azureMigrator) IsMigrated() (bool, error) {

--- a/pkg/migration/spec.go
+++ b/pkg/migration/spec.go
@@ -8,9 +8,16 @@ type MigratorFactory interface {
 }
 
 type Migrator interface {
+	// Cleanup performs cleanup operations after migration has been completed.
+	Cleanup() error
+
 	// IsMigrated performs check to see if given cluster has been already
 	// migrated.
 	IsMigrated() (bool, error)
+
+	// IsMigrating performs check to see if given cluster has migration
+	// triggered already.
+	IsMigrating() (bool, error)
 
 	// Prepare executes preparatory migration actions such as transforming
 	// existing CRs into upstream compatible format and creating missing CRs.

--- a/pkg/migration/spec.go
+++ b/pkg/migration/spec.go
@@ -11,7 +11,7 @@ type Migrator interface {
 	// existing CRs into upstream compatible format and creating missing CRs.
 	Prepare() error
 
-	// Migrate performs final execution which shifts reconciliation to upstream
-	// controllers.
-	Migrate() error
+	// TriggerMigration performs final execution which shifts reconciliation to
+	// upstream controllers.
+	TriggerMigration() error
 }

--- a/pkg/migration/spec.go
+++ b/pkg/migration/spec.go
@@ -1,0 +1,7 @@
+// Package migration provides implementation for CR migration from Giant Swarm
+// flavor to upstream compatible CAPI.
+package migration
+
+type Migrator interface {
+	Migrate() error
+}

--- a/pkg/migration/spec.go
+++ b/pkg/migration/spec.go
@@ -2,6 +2,11 @@
 // flavor to upstream compatible CAPI.
 package migration
 
+type MigratorFactory interface {
+	// Construct new Migrator for given cluster.
+	NewMigrator(clusterID string) (Migrator, error)
+}
+
 type Migrator interface {
 	// IsMigrated performs check to see if given cluster has been already
 	// migrated.

--- a/pkg/migration/spec.go
+++ b/pkg/migration/spec.go
@@ -3,5 +3,15 @@
 package migration
 
 type Migrator interface {
+	// IsMigrated performs check to see if given cluster has been already
+	// migrated.
+	IsMigrated() (bool, error)
+
+	// Prepare executes preparatory migration actions such as transforming
+	// existing CRs into upstream compatible format and creating missing CRs.
+	Prepare() error
+
+	// Migrate performs final execution which shifts reconciliation to upstream
+	// controllers.
 	Migrate() error
 }


### PR DESCRIPTION
This introduces `Migrator` interface which can be implemented for
different providers in suitable way.

Azure implementation stub is accompanied as an example of how provider
specific implementation could look like in the high level.