### PR TITLE
Add dev overlay and undeploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,11 @@ uninstall: manifests
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
-	cd config/manager && kustomize edit set image controller=${IMG}
-	kustomize build config/default | kubectl apply -f -
+	cd config/dev && kustomize edit set image controller=${IMG}
+	kustomize build config/dev | kubectl apply -f -
+
+undeploy:
+	kustomize build config/dev | kubectl delete -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ deploy: manifests
 	cd config/dev && kustomize edit set image controller=${IMG}
 	kustomize build config/dev | kubectl apply -f -
 
-undeploy:
+# Undeploy controller in the configured Kubernetes cluster in ~/.kube/config
+undeploy: manifests
 	kustomize build config/dev | kubectl delete -f -
 
 # Generate manifests e.g. CRD, RBAC etc.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: capi-migration-system
 namePrefix: capi-migration-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app.kubernetes.io/name: capi-migration
 
 bases:
 - ../crd

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -5,6 +5,8 @@ images:
   newName: giantswarm/capi-migration
   newTag: latest
 
+bases:
+- ../default
+
 resources:
 - namespace.yaml
-- ../default

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -1,0 +1,10 @@
+namespace: capi-migration-system-dev
+
+images:
+- name: controller
+  newName: giantswarm/capi-migration
+  newTag: latest
+
+resources:
+- namespace.yaml
+- ../default

--- a/config/dev/namespace.yaml
+++ b/config/dev/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16104
Part of: https://github.com/giantswarm/capi-migration/pull/1

- Add `dev` base
- Remove namespace creation from `manager` base
- Switch `make deploy` to `dev` base
- Add `make undeploy`

---

The general idea is you do `make deploy` to deploy to your current kube context cluster. The code will be deployed to a separate `capi-migration-system-dev` namespace.