### PR TITLE
Add PSP

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,6 +15,7 @@ commonLabels:
 bases:
 - ../crd
 - ../rbac
+- ../psp
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
 # crd/kustomization.yaml

--- a/config/psp/kustomization.yaml
+++ b/config/psp/kustomization.yaml
@@ -1,0 +1,7 @@
+configurations:
+- namereference.yaml
+
+resources:
+- psp.yaml
+- psp_role.yaml
+- psp_role_binding.yaml

--- a/config/psp/namereference.yaml
+++ b/config/psp/namereference.yaml
@@ -1,0 +1,7 @@
+nameReference:
+- kind: PodSecurityPolicy
+  fieldSpecs:
+  - path: rules/resourceNames
+    kind: Role
+  - path: rules/resourceNames
+    kind: ClusterRole

--- a/config/psp/psp.yaml
+++ b/config/psp/psp.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: controller-manager-psp
+spec:
+  privileged: false
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+  runAsUser:
+    rule: MustRunAsNonRoot
+  runAsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'secret'
+    - 'configMap'
+    - 'hostPath'
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false

--- a/config/psp/psp_role.yaml
+++ b/config/psp/psp_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: controller-manager-psp
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - controller-manager-psp

--- a/config/psp/psp_role_binding.yaml
+++ b/config/psp/psp_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: controller-manager-psp 
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: controller-manager-psp
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16355

Diff of `kustomize build config/dev`:

```diff
diff --git a/pawel.old.yaml b/pawel.new.yaml
index ade6450..cf78b29 100644
--- a/pawel.old.yaml
+++ b/pawel.new.yaml
@@ -11,6 +11,39 @@ metadata:
   name: capi-migration-controller-manager
   namespace: capi-migration-system-dev
 ---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: capi-migration
+  name: capi-migration-controller-manager-psp
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  runAsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - secret
+  - configMap
+  - hostPath
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -48,6 +81,22 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: capi-migration
+  name: capi-migration-controller-manager-psp
+rules:
+- apiGroups:
+  - extensions
+  resourceNames:
+  - capi-migration-controller-manager-psp
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
@@ -93,6 +142,21 @@ subjects:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: capi-migration
+  name: capi-migration-controller-manager-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-migration-controller-manager-psp
+subjects:
+- kind: ServiceAccount
+  name: capi-migration-controller-manager
+  namespace: capi-migration-system-dev
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: capi-migration
```