### PR TITLE
set team hydra as owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @giantswarm/team-hydra


### PR DESCRIPTION
Set team Hydra as owner. See ownership [doc](https://docs.google.com/spreadsheets/d/1GNXAbYo_HyjjRusd2KTGttuORBkX9iMdgnNp-xTQ9sw/edit#gid=0).

Team Hydra will probably work on the AWS CAPI migration topic.